### PR TITLE
add binder environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+name: example-environment
+channels:
+  - conda-forge
+dependencies:
+  - pyccl
+  - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - pyccl
   - matplotlib
+  - cython

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+#!/bin/bash
+git clone https://github.com/lesgourg/class_public.git
+cd class_public
+make
+cd ..


### PR DESCRIPTION
With this files all the notebooks can be run online in binder by going to

http://mybinder.org/v2/gh/LSSTDESC/CCLX/master

(esp. useful for Windows users who can't easily run CCL locally yet). Could also add direct binder-online notebook links to the readme (just add "?filepath=..." at the end to link to specific file)